### PR TITLE
Add automatic GitHub URL normalization to raw.githubusercontent.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## History (reverse chronological order)
 
+### v2.5.0 - 2026-01-12
+
+- Add automatic conversion of GitHub URLs to `raw.githubusercontent.com` format during sync
+  - Converts both `/blob/` and `/raw/` URLs from `github.com` domain
+  - Applies to all file URLs in modinfo and toolinfo files
+  - Also applies to imageURL and readmeURL fields
+  - Warnings added to alert users to update source files
+  - Ensures compatibility with GitHub's current raw file hosting on `raw.githubusercontent.com`
+
 ### v2.4.1 - 2026-01-12
 
 - Fix JSON parsing error messages during sync to show concise error instead of full stack trace

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    Icarus-Mod-Tools (2.4.1)
+    Icarus-Mod-Tools (2.5.0)
       google-cloud-firestore (~> 2.7)
       octokit (~> 6.0)
       paint (~> 2.3)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Options:
       [--dry-run], [--no-dry-run]  # Dry run (no changes will be made)
 ```
 
+**Note**: Sync operations automatically convert GitHub URLs to the correct `raw.githubusercontent.com` format for direct downloads. If you're using GitHub URLs in `modinfo.json` or `toolinfo.json` files, you can use either `/blob/` or `/raw/` formats and they will be automatically converted. Warnings will be displayed when URLs are auto-fixed so you can update your source files.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/icarus/mod/tools/baseinfo.rb
+++ b/lib/icarus/mod/tools/baseinfo.rb
@@ -172,6 +172,9 @@ module Icarus
         end
 
         def normalize_github_urls_in_data
+          # Skip normalization if data is frozen (e.g., from Firestore)
+          return if @data.frozen?
+
           @data[:imageURL] = normalize_github_url(@data[:imageURL])
           @data[:readmeURL] = normalize_github_url(@data[:readmeURL])
         end

--- a/lib/icarus/mod/tools/modinfo.rb
+++ b/lib/icarus/mod/tools/modinfo.rb
@@ -27,6 +27,9 @@ module Icarus
         def normalize_github_urls_in_data
           super # Handle imageURL and readmeURL
 
+          # Skip normalization if data is frozen (e.g., from Firestore)
+          return if @data.frozen?
+
           # Normalize each file URL in the files hash
           return unless @data[:files].is_a?(Hash)
 

--- a/lib/icarus/mod/tools/modinfo.rb
+++ b/lib/icarus/mod/tools/modinfo.rb
@@ -21,6 +21,19 @@ module Icarus
 
           super
         end
+
+        private
+
+        def normalize_github_urls_in_data
+          super # Handle imageURL and readmeURL
+
+          # Normalize each file URL in the files hash
+          return unless @data[:files].is_a?(Hash)
+
+          @data[:files].transform_values! do |url|
+            normalize_github_url(url)
+          end
+        end
       end
     end
   end

--- a/lib/icarus/mod/tools/toolinfo.rb
+++ b/lib/icarus/mod/tools/toolinfo.rb
@@ -24,6 +24,9 @@ module Icarus
         def normalize_github_urls_in_data
           super # Handle imageURL and readmeURL
 
+          # Skip normalization if data is frozen (e.g., from Firestore)
+          return if @data.frozen?
+
           # Normalize fileURL
           @data[:fileURL] = normalize_github_url(@data[:fileURL])
         end

--- a/lib/icarus/mod/tools/toolinfo.rb
+++ b/lib/icarus/mod/tools/toolinfo.rb
@@ -21,6 +21,13 @@ module Icarus
 
         private
 
+        def normalize_github_urls_in_data
+          super # Handle imageURL and readmeURL
+
+          # Normalize fileURL
+          @data[:fileURL] = normalize_github_url(@data[:fileURL])
+        end
+
         def filetype_pattern
           /(zip|exe)/i
         end

--- a/lib/icarus/mod/version.rb
+++ b/lib/icarus/mod/version.rb
@@ -2,6 +2,6 @@
 
 module Icarus
   module Mod
-    VERSION = "2.4.1"
+    VERSION = "2.5.0"
   end
 end

--- a/spec/icarus/mod/tools/toolinfo_spec.rb
+++ b/spec/icarus/mod/tools/toolinfo_spec.rb
@@ -75,4 +75,35 @@ RSpec.describe Icarus::Mod::Tools::Toolinfo do
       end
     end
   end
+
+  describe "GitHub URL normalization" do
+    context "when fileURL contains GitHub blob URL" do
+      let(:toolinfo_with_blob) do
+        {
+          name: "Test Tool",
+          author: "Test",
+          description: "Test",
+          version: "1.0",
+          fileType: "zip",
+          fileURL: "https://github.com/user/repo/blob/main/tool.zip",
+          imageURL: "https://github.com/user/repo/raw/main/img.png"
+        }
+      end
+
+      it "normalizes fileURL" do
+        test_toolinfo = described_class.new(toolinfo_with_blob)
+        expect(test_toolinfo.fileURL).to eq("https://raw.githubusercontent.com/user/repo/main/tool.zip")
+      end
+
+      it "normalizes inherited URLs" do
+        test_toolinfo = described_class.new(toolinfo_with_blob)
+        expect(test_toolinfo.imageURL).to eq("https://raw.githubusercontent.com/user/repo/main/img.png")
+      end
+
+      it "adds warnings for normalized URLs" do
+        test_toolinfo = described_class.new(toolinfo_with_blob)
+        expect(test_toolinfo.warnings.length).to eq(2) # fileURL, imageURL
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements GitHub Issue #3: Auto-fix GitHub URLs during sync operations.

This PR adds automatic conversion of GitHub URLs from `/blob/` and `/raw/` formats to the correct `raw.githubusercontent.com` format. This ensures compatibility with GitHub's current raw file hosting and prevents download failures from incorrect URL formats.

## Changes

- **URL Normalization Logic**: Added regex-based pattern matching in `Baseinfo` class to detect and convert GitHub URLs
- **Modinfo Support**: Override in `Modinfo` to handle the `files` hash containing multiple file types
- **Toolinfo Support**: Override in `Toolinfo` to handle the `fileURL` field  
- **Warning System**: Warnings added to alert users when URLs are auto-fixed so they can update their source files
- **Comprehensive Tests**: Added 21 new test cases covering various URL formats and edge cases

## Files Modified

- `lib/icarus/mod/tools/baseinfo.rb` - Core normalization logic with regex pattern
- `lib/icarus/mod/tools/modinfo.rb` - Override for files hash normalization
- `lib/icarus/mod/tools/toolinfo.rb` - Override for fileURL normalization
- `spec/icarus/mod/tools/baseinfo_spec.rb` - +103 lines of test coverage
- `spec/icarus/mod/tools/modinfo_spec.rb` - +41 lines of test coverage
- `spec/icarus/mod/tools/toolinfo_spec.rb` - +31 lines of test coverage
- `lib/icarus/mod/version.rb` - Version bump to 2.5.0
- `CHANGELOG.md` - Added v2.5.0 entry
- `README.md` - Added note about automatic URL conversion

## URL Transformation Examples

- `https://github.com/owner/repo/blob/main/file.zip` → `https://raw.githubusercontent.com/owner/repo/main/file.zip`
- `https://github.com/owner/repo/raw/main/file.zip` → `https://raw.githubusercontent.com/owner/repo/main/file.zip`

## Test Results

All 324 tests passing (21 new tests added).

## Version

2.5.0 (minor version bump - new feature)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)